### PR TITLE
fix: use window.timeout to resolve typescript errors

### DIFF
--- a/src/app/components/Page.ts
+++ b/src/app/components/Page.ts
@@ -170,7 +170,7 @@ export default class Page implements ClassComponent<PageAttrs> {
             else {
                 innerItemAttrs.height = document.documentElement.clientHeight;
                 if(vnode.attrs.index === slider.currentSlide)
-                    setTimeout(() => {
+                    window.setTimeout(() => {
                         //document.documentElement.style.overflowY = "hidden";
                     }, 50);
                 innerItemAttrs.onload = (e: Event) => {

--- a/src/app/components/Reader.ts
+++ b/src/app/components/Reader.ts
@@ -114,7 +114,7 @@ export default class Reader implements ClassComponent<ReaderAttrs> {
 
     resizeHandler() {
         clearTimeout(this.resizer);
-        this.resizer = setTimeout(() => {
+        this.resizer = window.setTimeout(() => {
             m.redraw();
             if(this.direction == XBReadingDirection.TTB && this.slider)
                 this.slider.slideToCurrent();
@@ -146,7 +146,7 @@ export default class Reader implements ClassComponent<ReaderAttrs> {
         if(this.slider.zoomer) this.slider.zoomer.scale = 1;
         this.guideHidden = this.config.guideHidden;
         clearTimeout(this.guideHider);
-        this.guideHider = setTimeout(() => {
+        this.guideHider = window.setTimeout(() => {
             if(this.guideHidden) return;
             this.guideHidden = true;
             m.redraw();
@@ -233,7 +233,7 @@ export default class Reader implements ClassComponent<ReaderAttrs> {
             this.switchDirection(this.publication.direction);
             this.config.onBeforeReady(this);
             m.redraw();
-            setTimeout(() => {
+            window.setTimeout(() => {
                 if(this.ui && !this.ui.mousing)
                     this.ui.toggle(false);
                 m.redraw();

--- a/src/app/helpers/lazyLoader.ts
+++ b/src/app/helpers/lazyLoader.ts
@@ -167,7 +167,7 @@ export default class LazyLoader {
 
         // If index of page near current page, load after predicted end of transition
         else if(diff <= HIGH_THRESHOLD) {
-            this.highTime = setTimeout(() => {
+            this.highTime = window.setTimeout(() => {
                 this.prepare();
             }, 1000);
 
@@ -313,7 +313,7 @@ export default class LazyLoader {
                 }
             };
             (<HTMLImageElement>this.preloader).onerror = () => {
-                setTimeout(() => {
+                window.setTimeout(() => {
                     if(!this.loaded && this.preloader) {
                         console.error("Error loading page " + this.original);
                         this.blob = null;
@@ -337,7 +337,7 @@ export default class LazyLoader {
                 }
                 // this.blob = img;
             }).catch((err: Error) => {
-                setTimeout(() => {
+                window.setTimeout(() => {
                     if(!this.loaded && this.preloader) {
                         console.error(`Error fetching page ${this.original}\n${err}`);
                         this.blob = null;

--- a/src/app/helpers/peripherals.ts
+++ b/src/app/helpers/peripherals.ts
@@ -302,7 +302,7 @@ export default class Peripherals {
 
     mtimerUpdater(e: MithrilEvent) { // TODO mithril event type
         e.redraw = false;
-        setTimeout(() => {
+        window.setTimeout(() => {
             clearTimeout(this.mtimer);
         }, 100);
     }
@@ -318,7 +318,7 @@ export default class Peripherals {
         if (this.drag.endX) {
             this.updateAfterDrag();
         }
-        setTimeout(() => {
+        window.setTimeout(() => {
             this.clearDrag();
         }, 50);
     }
@@ -451,7 +451,7 @@ export default class Peripherals {
         } else {
             if(!e.special) {
                 clearTimeout(this.mtimer);
-                const mouseIt = setTimeout(() => {
+                const mouseIt = window.setTimeout(() => {
                     this.ui.mousing = false; // Race!
                 }, 50);
                 this.mousePos = this.coordinator.getBibiEvent(e);
@@ -460,7 +460,7 @@ export default class Peripherals {
                     this.ui.mousing = true;
                     this.ui.toggle(true);
                 } else {
-                    this.mtimer = setTimeout(() => {
+                    this.mtimer = window.setTimeout(() => {
                         if(this.mousePosOut || this.ui.mousing)
                             return;
                         this.ui.toggle(false);
@@ -746,7 +746,7 @@ export default class Peripherals {
             // When rapidly navigating, ignore double clicks until cooldown
             this.disableDblClick = true;
             clearTimeout(this.dblDisabler);
-            this.dblDisabler = setTimeout(() => {
+            this.dblDisabler = window.setTimeout(() => {
                 this.disableDblClick = false;
             }, 1000);
         } else if (typeof MovingParameter == "string") {
@@ -819,7 +819,7 @@ export default class Peripherals {
     }
 
     delayedMoveBy(MovingParameter: any) {
-        this.dtimer = setTimeout(() => {
+        this.dtimer = window.setTimeout(() => {
             if (!this.pdblclick) {
                 this.moveBy(MovingParameter);
             }
@@ -923,7 +923,7 @@ export default class Peripherals {
         if (CW.Wheeled !== WheelState.None) {
             Eve.BibiSwiperWheel = CW;
             clearTimeout(this.Timer_cooldown);
-            this.Timer_cooldown = setTimeout(() => this.onwheeled_hot = false, 300);
+            this.Timer_cooldown = window.setTimeout(() => this.onwheeled_hot = false, 300);
             if (!this.onwheeled_hot && !this.processVScroll()) {
                 Eve.preventDefault();
                 this.onwheeled_hot = true;
@@ -933,7 +933,7 @@ export default class Peripherals {
         if (PWl >= 3) PWs.shift();
         PWs.push(CW);
         clearTimeout(this.onwheelTimer_stop);
-        this.onwheelTimer_stop = setTimeout(() => {
+        this.onwheelTimer_stop = window.setTimeout(() => {
             this.PreviousWheels = [];
         }, 192);
     }
@@ -945,7 +945,7 @@ export default class Peripherals {
         }
         //E.dispatch("bibi:scrolls", Eve);
         clearTimeout(this.Timer_onscrolled);
-        this.Timer_onscrolled = setTimeout(() => {
+        this.Timer_onscrolled = window.setTimeout(() => {
             this.Scrolling = false;
         }, 123);
     }

--- a/src/app/models/Slider.ts
+++ b/src/app/models/Slider.ts
@@ -283,7 +283,7 @@ export default class Slider {
             return;
         }
         if(this.single && !this.ttb) // Scroll back to top for next page
-            setTimeout(() => {
+            window.setTimeout(() => {
                 this && this.binder && this.binder.coordinator && this.binder.coordinator.HTML && this.binder.coordinator.HTML.scrollTo(0, 0);
             }, 100);
 


### PR DESCRIPTION
Fixes these errors:
```
ERROR in xbreader/src/app/components/Reader.ts
./src/app/components/Reader.ts
[tsl] ERROR in xbreader/src/app/components/Reader.ts(117,9)
      TS2322: Type 'Timeout' is not assignable to type 'number'.

ERROR in xbreader/src/app/components/Reader.ts
./src/app/components/Reader.ts
[tsl] ERROR in xbreader/src/app/components/Reader.ts(149,9)
      TS2322: Type 'Timeout' is not assignable to type 'number'.

ERROR in xbreader/src/app/helpers/lazyLoader.ts
./src/app/helpers/lazyLoader.ts
[tsl] ERROR in xbreader/src/app/helpers/lazyLoader.ts(170,13)
      TS2322: Type 'Timeout' is not assignable to type 'number'.

ERROR in xbreader/src/app/helpers/peripherals.ts
./src/app/helpers/peripherals.ts
[tsl] ERROR in xbreader/src/app/helpers/peripherals.ts(463,21)
      TS2322: Type 'Timeout' is not assignable to type 'number'.

ERROR in xbreader/src/app/helpers/peripherals.ts
./src/app/helpers/peripherals.ts
[tsl] ERROR in xbreader/src/app/helpers/peripherals.ts(926,13)
      TS2322: Type 'Timeout' is not assignable to type 'number'.

ERROR in xbreader/src/app/helpers/peripherals.ts
./src/app/helpers/peripherals.ts
[tsl] ERROR in xbreader/src/app/helpers/peripherals.ts(936,9)
      TS2322: Type 'Timeout' is not assignable to type 'number'.

ERROR in xbreader/src/app/helpers/peripherals.ts
./src/app/helpers/peripherals.ts
[tsl] ERROR in xbreader/src/app/helpers/peripherals.ts(948,9)
      TS2322: Type 'Timeout' is not assignable to type 'number'.
```